### PR TITLE
Update license to BSD-3 (Main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This file tracks notable changes to **nrelWattileExt**. The format is based on
 
 [View Changes](https://github.com/NREL/nrelWattileExt/compare/main...develop)
 
+### Changed
+
+- Update license to BSD-3
+
 ## [v0.2.1] (2024-07-09)
 
 [v0.2.1]: https://github.com/NREL/nrelWattileExt/releases/tag/v0.2.1

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,11 @@
-**nrelWattileExt** is currently NREL internal use only; this is a placeholder
+**nrelWattileExt** Copyright (c) 2024 Alliance for Sustainable Energy, LLC. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions, and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. The name of the copyright holder(s), any contributors, the United States Government, the United States Department of Energy, or any of their employees may not be used to endorse or promote products derived from this software without specific prior written permission from the respective party.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -328,5 +328,6 @@ minimal SkySpark test environment for developing and testing functions and workf
 License
 -------
 
-NREL internal use only (but stay tuned!)
+This software is licensed for use under the terms of the Berkeley Software
+Distribution 3-clause (BSD-3) license; see `LICENSE.md`.
 

--- a/build.fan
+++ b/build.fan
@@ -24,7 +24,7 @@ class Build : BuildPod
                 "org.uri":         "https://www.nrel.gov/",
                 "proj.name":       "NREL Wattile Extension",
                 "proj.uri":        "https://github.com/NREL/nrelWattileExt/",
-                "license.name":    "Commercial", // TO DO: Update when open source
+                "license.name":    "BSD-3",
               ]
     depends = ["sys 1.0+"]
     resDirs = [`lib/`, `locale/`]


### PR DESCRIPTION
Update license to BSD-3. Merge to `main` for open-sourcing **nrelWattileExt** repo.